### PR TITLE
Cached workflow proxy generation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --dev --prefer-source
+  - composer install --dev
 
 script: phpunit --coverage-text
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --dev
+  - composer install
 
 script: phpunit --coverage-text
 

--- a/Manager/WorkflowManager.php
+++ b/Manager/WorkflowManager.php
@@ -29,6 +29,12 @@ class WorkflowManager
      * @var \Kitpages\StepBundle\Step\StepManager
      */
     protected $stepManager;
+
+    /**
+     * @var ProxyGenerator
+     */
+    protected $proxyGenerator;
+
     /**
      * @var WorkflowInterface[]
      */
@@ -50,22 +56,25 @@ class WorkflowManager
     protected $logger;
 
     /**
-     * @param EventDispatcherInterface $eventDispatcher
+     * @param EventDispatcherInterface         $eventDispatcher
      * @param WorkflowStorageStrategyInterface $storageStrategy
-     * @param StepManager $stepManager
-     * @param $defaultStepName
-     * @param LoggerInterface $logger
+     * @param StepManager                      $stepManager
+     * @param ProxyGenerator                   $proxyGenerator
+     * @param string                           $defaultStepName
+     * @param LoggerInterface                  $logger
      */
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         WorkflowStorageStrategyInterface $storageStrategy,
         StepManager $stepManager,
+        ProxyGenerator $proxyGenerator,
         $defaultStepName,
         LoggerInterface $logger
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->storageStrategy = $storageStrategy;
         $this->stepManager = $stepManager;
+        $this->proxyGenerator = $proxyGenerator;
         $this->defaultStepName = $defaultStepName;
         $this->logger = $logger;
     }
@@ -201,9 +210,7 @@ class WorkflowManager
      */
     public function generateWorkflowProxy()
     {
-        $className = '\\Kitpages\\WorkflowBundle\\Model\\Workflow';
-        $proxyGenerator = new ProxyGenerator();
-        $workflow = $proxyGenerator->generateProcessProxy($className);
+        $workflow = $this->proxyGenerator->generateProcessProxy();
         $workflow->__workflowProxySetEventDispatcher($this->eventDispatcher);
 
         return $workflow;

--- a/Proxy/CacheClearer/ProxyCacheClearer.php
+++ b/Proxy/CacheClearer/ProxyCacheClearer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kitpages\WorkflowBundle\Proxy\CacheClearer;
+
+use Kitpages\WorkflowBundle\Proxy\ProxyGenerator;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+/**
+ * Removes the proxy cache file when the cache is cleared.
+ *
+ * @author Hugues Maignol <hugues.maignol@kitpages.fr>
+ */
+class ProxyCacheClearer implements CacheClearerInterface
+{
+    /**
+     * @var ProxyGenerator
+     */
+    private $proxyGenerator;
+
+    /**
+     * ProxyCacheClearer constructor.
+     *
+     * @param ProxyGenerator $proxyGenerator
+     */
+    public function __construct(ProxyGenerator $proxyGenerator)
+    {
+        $this->proxyGenerator = $proxyGenerator;
+    }
+
+    /**
+     * Clears any caches necessary.
+     *
+     * @param string $cacheDir The cache directory.
+     */
+    public function clear($cacheDir)
+    {
+        $fs = new Filesystem();
+        $cacheFile = $this->proxyGenerator->getProxyCacheFilename($cacheDir);
+        if ($fs->exists($cacheFile)) {
+            $fs->remove($cacheFile);
+        }
+    }
+}

--- a/Proxy/CacheClearer/ProxyCacheClearer.php
+++ b/Proxy/CacheClearer/ProxyCacheClearer.php
@@ -36,7 +36,7 @@ class ProxyCacheClearer implements CacheClearerInterface
     public function clear($cacheDir)
     {
         $fs = new Filesystem();
-        $cacheFile = $this->proxyGenerator->getProxyCacheFilename($cacheDir);
+        $cacheFile = $this->proxyGenerator->getProxyCacheFilename();
         if ($fs->exists($cacheFile)) {
             $fs->remove($cacheFile);
         }

--- a/Proxy/CacheWarmer/ProxyCacheWarmer.php
+++ b/Proxy/CacheWarmer/ProxyCacheWarmer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kitpages\WorkflowBundle\Proxy\CacheWarmer;
+
+use Kitpages\WorkflowBundle\Proxy\ProxyGenerator;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Removes the proxy cache file when the cache is cleared.
+ *
+ * @author Hugues Maignol <hugues.maignol@kitpages.fr>
+ */
+class ProxyCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @var ProxyGenerator
+     */
+    private $proxyGenerator;
+
+    /**
+     * ProxyCacheClearer constructor.
+     *
+     * @param ProxyGenerator $proxyGenerator
+     */
+    public function __construct(ProxyGenerator $proxyGenerator)
+    {
+        $this->proxyGenerator = $proxyGenerator;
+    }
+
+    /**
+     * We need the workflow proxies in the cache.
+     *
+     * @return bool false
+     */
+    public function isOptional()
+    {
+        return false;
+    }
+
+    /**
+     * Writes the workflow proxy cache file.
+     *
+     * @param string $cacheDir The cache directory
+     */
+    public function warmUp($cacheDir)
+    {
+        $this->proxyGenerator->generateProcessProxyClass();
+    }
+}

--- a/Proxy/CacheWarmer/ProxyCacheWarmer.php
+++ b/Proxy/CacheWarmer/ProxyCacheWarmer.php
@@ -44,6 +44,6 @@ class ProxyCacheWarmer implements CacheWarmerInterface
      */
     public function warmUp($cacheDir)
     {
-        $this->proxyGenerator->generateProcessProxyClass();
+        $this->proxyGenerator->writeProxyClassCache();
     }
 }

--- a/Proxy/ProxyGenerator.php
+++ b/Proxy/ProxyGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kitpages\StepBundle\Proxy;
+namespace Kitpages\WorkflowBundle\Proxy;
 
 use Symfony\Component\Filesystem\Filesystem;
 use ReflectionClass;

--- a/Proxy/ProxyGenerator.php
+++ b/Proxy/ProxyGenerator.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Kitpages\WorkflowBundle\Proxy;
+namespace Kitpages\StepBundle\Proxy;
 
-use ReflectionClass;
 use Symfony\Component\Filesystem\Filesystem;
+use ReflectionClass;
 
 /**
- * This class is a factory for generating a proxy for a workflow.
+ * This class is used to generate a proxy for a step command
  *
  * @example
  */
@@ -60,7 +60,7 @@ class ProxyGenerator
     /**
      * @param string $class    The class that will proxy
      * @param bool   $debug
-     * @param        $cacheDir
+     * @param string $cacheDir
      */
     public function __construct($class, $debug, $cacheDir)
     {
@@ -75,7 +75,7 @@ class ProxyGenerator
     }
 
     /**
-     * Instantiate and returns a workflow proxy.
+     * Instantiate and returns a proxy instance.
      *
      * @param array $arguments (optionnal) The arguments to pass to the constructor of the Proxy Class if needed
      *
@@ -86,6 +86,7 @@ class ProxyGenerator
         if (!$this->isProxyLoaded()) {
             $this->loadProxyClass();
         }
+
         $reflect = new ReflectionClass($this->proxyClass);
 
         return $reflect->newInstanceArgs($arguments);
@@ -121,7 +122,9 @@ class ProxyGenerator
             $this->writeProxyClassCache();
         }
 
-        require $this->proxyClassCacheFilename;
+        if(!$this->isProxyLoaded()) {
+            require $this->proxyClassCacheFilename;
+        }
 
         return $this;
     }
@@ -134,10 +137,21 @@ class ProxyGenerator
     public function getProxyCacheFilename()
     {
         return sprintf(
-            '%s/kitpages_proxy/%s.php',
+            '%s/kitpages_proxy/%s_%s.php',
             $this->cacheDir,
-            str_replace('\\', '_', $this->proxyClass)
+            md5($this->proxyClass),
+            $this->getShortClassName()
         );
+    }
+
+    /**
+     * Getter de proxyClass
+     *
+     * @return string
+     */
+    public function getProxyClass()
+    {
+        return $this->proxyClass;
     }
 
     /**

--- a/Proxy/ProxyGenerator.php
+++ b/Proxy/ProxyGenerator.php
@@ -1,41 +1,97 @@
 <?php
+
 namespace Kitpages\WorkflowBundle\Proxy;
 
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
- * This class is used to generate a proxy for a workflow
+ * This class is used to generate a proxy for a workflow.
  *
  * @example
  */
 class ProxyGenerator
 {
-    public function __construct()
+    /**
+     * The class of the workflow.
+     *
+     * @var string
+     */
+    protected $workflowClass;
+
+    /**
+     * Debug mode.
+     *
+     * @var bool
+     */
+    protected $debug;
+
+    /**
+     * The main cache directory.
+     *
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
+     * @var string
+     */
+    protected $proxyClassCacheFilename;
+
+    /**
+     * @param      $workflowClass
+     * @param bool $debug
+     * @param      $cacheDir
+     */
+    public function __construct($workflowClass, $debug, $cacheDir)
     {
+        $this->workflowClass = $workflowClass;
+        $this->debug = $debug;
+        $this->cacheDir = $cacheDir;
+        $this->proxyClassCacheFilename = $this->getProxyCacheFilename($cacheDir);
     }
 
-    public function generateProcessProxy($originalClassName)
+    /**
+     * @param string $cacheDir
+     *
+     * @return string
+     */
+    public function getProxyCacheFilename($cacheDir)
     {
+        return $cacheDir.'/kitpages_workflow/WorkflowProxy.php';
+    }
+
+    /**
+     * @param string $originalClassName (optionnel) Can be specified for backward compatibility.
+     *
+     * @return mixed
+     */
+    public function generateProcessProxy($originalClassName = null)
+    {
+        $originalClassName = $originalClassName ?: $this->workflowClass;
+
         $className = $this->generateProcessProxyClass($originalClassName);
         $proxy = new $className();
 
         return $proxy;
     }
 
-    public function generateProcessProxyClass($originalClassName)
+    public function generateProcessProxyClass($originalClassName = null)
     {
+        $originalClassName = $originalClassName ?: $this->workflowClass;
         $proxyClassName = $this->getProxyClassName($originalClassName);
         if (class_exists($proxyClassName)) {
             return $proxyClassName;
         }
 
         $parameters = array(
-            "proxyNameSpace" => $this->getProxyNameSpace($originalClassName),
-            "proxyClassName" => $this->getProxyClassName($originalClassName),
-            "shortClassName" => $this->getShortClassName($originalClassName),
-            "originalClassName" => $originalClassName
+            'proxyNameSpace' => $this->getProxyNameSpace($originalClassName),
+            'proxyClassName' => $this->getProxyClassName($originalClassName),
+            'shortClassName' => $this->getShortClassName($originalClassName),
+            'originalClassName' => $originalClassName,
         );
-        $templateFile = __DIR__ . '/ProxyTemplate.php.tpl';
+        $templateFile = __DIR__.'/ProxyTemplate.php.tpl';
 
-        return $this->generateProxyClass($originalClassName, file_get_contents($templateFile), $parameters);
+        return $this->generateProxyClass($originalClassName, $templateFile, $parameters);
     }
 
     public function getProxyNameSpace($originalClassName)
@@ -48,7 +104,7 @@ class ProxyGenerator
 
     public function getProxyClassName($originalClassName)
     {
-        return '\\' . __NAMESPACE__ . $originalClassName;
+        return '\\'.__NAMESPACE__.$originalClassName;
     }
 
     public function getShortClassName($originalClassName)
@@ -58,14 +114,21 @@ class ProxyGenerator
         return array_pop($proxyNameSpaceTab);
     }
 
-    public function generateProxyClass($originalClassName, $proxyTemplateContent, $parameters = array())
+    public function generateProxyClass($originalClassName, $templateFile, $parameters = array())
     {
+        $fs = new Filesystem();
         $proxyClassName = $this->getProxyClassName($originalClassName);
         if (class_exists($proxyClassName)) {
             return $proxyClassName;
         }
-        $proxyClassDefinition = $this->replaceInTemplate($proxyTemplateContent, $parameters);
-        eval($proxyClassDefinition);
+
+        if (!$fs->exists($this->proxyClassCacheFilename) || $this->debug) {
+            $proxyTemplateContent = file_get_contents($templateFile);
+            $proxyClassDefinition = $this->replaceInTemplate($proxyTemplateContent, $parameters);
+            $fs->dumpFile($this->proxyClassCacheFilename, $proxyClassDefinition);
+        }
+
+        require $this->proxyClassCacheFilename;
 
         return $proxyClassName;
     }

--- a/Proxy/ProxyGenerator.php
+++ b/Proxy/ProxyGenerator.php
@@ -2,8 +2,8 @@
 
 namespace Kitpages\WorkflowBundle\Proxy;
 
-use Symfony\Component\Filesystem\Filesystem;
 use ReflectionClass;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * This class is a factory for generating a proxy for a workflow.
@@ -86,13 +86,9 @@ class ProxyGenerator
         if (!$this->isProxyLoaded()) {
             $this->loadProxyClass();
         }
-        if (version_compare(phpversion(), '5.6.0', '<')) {
-            $reflect = new ReflectionClass($this->proxyClass);
+        $reflect = new ReflectionClass($this->proxyClass);
 
-            return $reflect->newInstanceArgs($arguments);
-        }
-
-        return new $this->proxyClass(...$arguments);
+        return $reflect->newInstanceArgs($arguments);
     }
 
     /**

--- a/Proxy/ProxyTemplate.php.tpl
+++ b/Proxy/ProxyTemplate.php.tpl
@@ -1,3 +1,4 @@
+<?php
 namespace <<proxyNameSpace>>;
 
     use Kitpages\WorkflowBundle\Proxy\ProxyInterface;

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,13 +7,22 @@
     <parameters>
         <parameter key="workflow.manager.class">Kitpages\WorkflowBundle\Manager\WorkflowManager</parameter>
         <parameter key="workflow.storage_strategy.class">Kitpages\WorkflowBundle\Storage\JsonWorkflowStorageStrategy</parameter>
+        <parameter key="workflow.proxy_generator.class">Kitpages\WorkflowBundle\Proxy\ProxyGenerator</parameter>
+        <parameter key="workflow.workflow.class">\Kitpages\WorkflowBundle\Model\Workflow</parameter>
+
     </parameters>
 
     <services>
+        <service id="workflow.proxy_generator" class="%workflow.proxy_generator.class%" public="false">
+            <argument>%workflow.workflow.class%</argument>
+            <argument>%kernel.debug%</argument>
+            <argument>%kernel.cache_dir%</argument>
+        </service>
         <service id="workflow.manager" class="%workflow.manager.class%">
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="workflow.storage_strategy"/>
             <argument type="service" id="kitpages_step.step"/>
+            <argument type="service" id="workflow.proxy_generator"/>
             <argument>%kitpages_workflow.default_step_name%</argument>
             <argument type="service" id="logger"/>
             <tag name="kernel.event_listener" event="kitpages_workflow.action" method="onActionEvent"/>
@@ -21,6 +30,16 @@
             <tag name="monolog.logger" channel="workflow" />
         </service>
         <service id="workflow.storage_strategy" class="%workflow.storage_strategy.class%">
+        </service>
+        <service id="workflow.proxy_cache_clearer"
+                 class="Kitpages\WorkflowBundle\Proxy\CacheClearer\ProxyCacheClearer">
+            <argument type="service" id="workflow.proxy_generator"/>
+            <tag name="kernel.cache_clearer" />
+        </service>
+        <service id="workflow.proxy_cache_warmer"
+                 class="Kitpages\WorkflowBundle\Proxy\CacheWarmer\ProxyCacheWarmer">
+            <argument type="service" id="workflow.proxy_generator"/>
+            <tag name="kernel.cache_warmer" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
@philippe-levan I didn't break BC in ProxyGenerator but I think we should for more clarity and performance :   
- Only generateProcessProxy() and getProxyCacheFilename() should be public and take no arguments
- A public writeCacheProxyFile() method should be added and public (used in cache warmer)
- The other public methods should be private and do only one thing, based on the ProxyGenerator attributes and not pass along variable between them.

This question is the same for StepBundle's ProxyGenerator.
